### PR TITLE
Improve test reliability by cleaning state pollution after running test_command_line_already_playlist

### DIFF
--- a/tests/test_m3u_dump.py
+++ b/tests/test_m3u_dump.py
@@ -10,6 +10,7 @@ Tests for `m3u_dump` module.
 import os
 
 import pytest
+import shutil
 
 from click.testing import CliRunner
 
@@ -220,6 +221,7 @@ def test_command_line_already_playlist(already_exists_playlist):
         assert '#EXTM3U' == f.readline().rstrip('\n')
         assert '#EXTINF:409,artist - music_name' == f.readline().rstrip('\n')
         assert 'already_path.mp3' == f.readline().rstrip('\n')
+    shutil.rmtree(dst_dir)
 
 
 # noinspection PyShadowingNames


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_command_line_already_playlist` by cleaning the state before running it.

The test can fail on the second run by running it twice: `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_m3u_dump.py::test_command_line_already_playlist`.
```
    def test_command_line_already_playlist(already_exists_playlist):
        music_path = os.path.join(str(already_exists_playlist), 'music')
        dst_dir = os.path.join(str(already_exists_playlist), 'dst')
>       os.mkdir(dst_dir)
E       FileExistsError: [Errno 17] File exists: '/tmp/pytest-of-rtp1/pytest-25/already-dir0/dst'

tests/test_m3u_dump.py:203: FileExistsError
```
This PR can resolve this issue. It may be better to avoid state pollutions so that some other tests won't fail in the future due to the shared state pollution.